### PR TITLE
allow #comment-eol (and fix parse error machinery)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -110,11 +110,12 @@ degrees into the input file, one vertex per line. If you are interested
 in whether the magnitude of earthquakes follow a power-law, dump the
 magnitudes into the input file, one earthquake per line. There is no
 need to calculate the cumulative distribution function or the probability
-density function before, nor to normalize the input data. Then simply run::
+density function before, nor to normalize the input data. Futhermore,
+inline comments using # (hash) are supported. Then simply run::
 
     $ ./plfit input_data.txt
 
-For some inspiration, see the sample data files under the directory ``test``.
+For some inspiration, see the sample data files under the directory ``data``.
 The program will assume that the data is discrete when the file contains
 integers only; otherwise it will assume that the data is continuous. If your
 data file contains integers only but you know that they come from a continuous

--- a/data/README.rst
+++ b/data/README.rst
@@ -35,7 +35,15 @@ Below is a description of the input data for the testsuite.
   assumptions.
 
 * The data file ``karate.dat`` contains the (total) degree sequence of
-  the Zachary karate club nework, as described in [Zachary1977]_.
+  the Zachary karate club network, as described in [Zachary1977]_.
+
+* The data files ``karate-commented.dat``, ``karate-commented_dos.dat``,
+	and ``karate-commented_corrupted.dat`` are *commented* version of the
+	data file ``karate.dat``. Inline comments with a single # (hash) as
+	left delimiter are supported: all the text from the ASCII character #
+	(35) to the end of the line is ignored. The first data file mainly
+	serves as illustration; the two others, with a self-explanatory
+	subscript, are mainly meant for testing.
 
 
 .. [Newman2001a]

--- a/data/karate-commented.dat
+++ b/data/karate-commented.dat
@@ -1,0 +1,71 @@
+## karate-commented.dat data file
+## contains the (total) degree sequence of Zachary karate club network
+## as described in [Zachary1977]
+##
+## BibTeX entries
+##@article{Zachary1977,
+##	author  = {Wayne W. Zachary},
+##	title   = {An Information Flow Model for Conflict and Fission in Small Groups},
+##	journal = {Journal of Anthropological Research},
+##	volume  = {33},
+##	number  = {4},
+##	pages   = {452-473},
+##	year    = {1977},
+##	doi     = {10.1086/jar.33.4.3629752},
+##	eprint  = {https://doi.org/10.1086/jar.33.4.3629752},
+##	abstract = {
+##		Data from a voluntary association are used to construct a new
+##		formal model for a traditional anthropological problem, fission
+##		in small groups. The process leading to fission is viewed as an
+##		unequal flow of sentiments and information across the ties in a
+##		social network. This flow is unequal because it is uniquely
+##		constrained by the contextual range and sensitivity of each
+##		relationship in the network. The subsequent differential sharing
+##		of sentiments leads to the formation of subgroups with more internal
+##		stability than the group as a whole, and results in fission.
+##		The Ford-Fulkerson labeling algorithm allows an accurate prediction
+##		of membership in the subgroups and of the locus of the fission to be
+##		made from measurements of the potential for information flow across
+##		each edge in the network. Methods for measurement of potential
+##		information flow are discussed, and it is shown that all appropriate
+##		techniques will generate the same predictions.}
+##	}
+## End of BibTeX entries
+##
+16# first datum
+9 # second datum
+10
+6
+3
+## the next line is an empty line
+
+4
+4
+4
+5
+##FaultyDatum##1009
+2
+3
+1
+2
+## the next four lines are not corrupted
+	5
+ 2  
+    2	
+	 2
+2
+2
+5
+	## tabbed comment
+3
+3
+2
+4
+3
+4
+4
+6
+12
+17 ## largest datum
+##
+## eof

--- a/data/karate-commented_corrupted.dat
+++ b/data/karate-commented_corrupted.dat
@@ -1,0 +1,72 @@
+## karate-commented.dat data file
+## contains the (total) degree sequence of Zachary karate club network
+## as described in [Zachary1977]
+##
+## BibTeX entries
+##@article{Zachary1977,
+##	author  = {Wayne W. Zachary},
+##	title   = {An Information Flow Model for Conflict and Fission in Small Groups},
+##	journal = {Journal of Anthropological Research},
+##	volume  = {33},
+##	number  = {4},
+##	pages   = {452-473},
+##	year    = {1977},
+##	doi     = {10.1086/jar.33.4.3629752},
+##	eprint  = {https://doi.org/10.1086/jar.33.4.3629752},
+##	abstract = {
+##		Data from a voluntary association are used to construct a new
+##		formal model for a traditional anthropological problem, fission
+##		in small groups. The process leading to fission is viewed as an
+##		unequal flow of sentiments and information across the ties in a
+##		social network. This flow is unequal because it is uniquely
+##		constrained by the contextual range and sensitivity of each
+##		relationship in the network. The subsequent differential sharing
+##		of sentiments leads to the formation of subgroups with more internal
+##		stability than the group as a whole, and results in fission.
+##		The Ford-Fulkerson labeling algorithm allows an accurate prediction
+##		of membership in the subgroups and of the locus of the fission to be
+##		made from measurements of the potential for information flow across
+##		each edge in the network. Methods for measurement of potential
+##		information flow are discussed, and it is shown that all appropriate
+##		techniques will generate the same predictions.}
+##	}
+## End of BibTeX entries
+##
+16# first datum
+9 # second datum
+10
+6
+3
+## the next line is an empty line
+
+4
+4
+4
+5
+##FaultyDatum##1009
+2
+3
+1
+2
+## the next four lines are not corrupted
+	5
+ 2  
+    2	
+	 2
+2
+2
+5
+	## tabbed comment
+3
+## the seven next lines are corrupted
+/*2*/
+//3
+(*4*)
+!3
+-- 4
+C 4
+' 6
+12
+17 ## largest datum
+##
+## eof

--- a/data/karate-commented_dos.dat
+++ b/data/karate-commented_dos.dat
@@ -1,0 +1,71 @@
+## karate-commented.dat data file
+## contains the (total) degree sequence of Zachary karate club network
+## as described in [Zachary1977]
+##
+## BibTeX entries
+##@article{Zachary1977,
+##	author  = {Wayne W. Zachary},
+##	title   = {An Information Flow Model for Conflict and Fission in Small Groups},
+##	journal = {Journal of Anthropological Research},
+##	volume  = {33},
+##	number  = {4},
+##	pages   = {452-473},
+##	year    = {1977},
+##	doi     = {10.1086/jar.33.4.3629752},
+##	eprint  = {https://doi.org/10.1086/jar.33.4.3629752},
+##	abstract = {
+##		Data from a voluntary association are used to construct a new
+##		formal model for a traditional anthropological problem, fission
+##		in small groups. The process leading to fission is viewed as an
+##		unequal flow of sentiments and information across the ties in a
+##		social network. This flow is unequal because it is uniquely
+##		constrained by the contextual range and sensitivity of each
+##		relationship in the network. The subsequent differential sharing
+##		of sentiments leads to the formation of subgroups with more internal
+##		stability than the group as a whole, and results in fission.
+##		The Ford-Fulkerson labeling algorithm allows an accurate prediction
+##		of membership in the subgroups and of the locus of the fission to be
+##		made from measurements of the potential for information flow across
+##		each edge in the network. Methods for measurement of potential
+##		information flow are discussed, and it is shown that all appropriate
+##		techniques will generate the same predictions.}
+##	}
+## End of BibTeX entries
+##
+16# first datum
+9 # second datum
+10
+6
+3
+## the next line is an empty line
+
+4
+4
+4
+5
+##FaultyDatum##1009
+2
+3
+1
+2
+## the next four lines are not corrupted
+	5
+ 2  
+    2	
+	 2
+2
+2
+5
+	## tabbed comment
+3
+3
+2
+4
+3
+4
+4
+6
+12
+17 ## largest datum
+##
+## eof

--- a/src/main.c
+++ b/src/main.c
@@ -28,6 +28,11 @@
 #include "platform.h"
 #include "plfit.h"
 
+/* exit status code for incorrect input data as defined in sysexits.h (8.1) */
+#ifndef EX_DATAERR
+#define EX_DATAERR 65
+#endif
+
 typedef struct _cmd_options_t {
     double alpha_min;
     double alpha_step;
@@ -263,10 +268,12 @@ void process_file(FILE* f, const char* fname) {
 
     if (warned) {
         fprintf(stderr, "%s: corrupted data points in file\n", fname);
+        exit(EX_DATAERR);
         return;
     }
     if (n == 0) {
         fprintf(stderr, "%s: no data points in file\n", fname);
+        exit(EX_DATAERR);
         return;
     }
 

--- a/src/main.c
+++ b/src/main.c
@@ -235,9 +235,13 @@ void process_file(FILE* f, const char* fname) {
             break;
 
         if (nparsed < 1) {   /* parse error */
-            if (!warned) {
-                fprintf(stderr, "%s: parse error at byte %ld\n", fname, (long)ftell(f));
-                warned = 1;
+            int c = '\0';
+            if ((c = fgetc(f)) == '#') {
+                do { c = fgetc(f); } while (c != '\n');
+            } else {
+                if (warned++ < 16) {
+                    fprintf(stderr, "%s: parse error at byte %ld\n", fname, (long)ftell(f));
+                }
             }
             continue;
         }
@@ -257,6 +261,10 @@ void process_file(FILE* f, const char* fname) {
         }
     }
 
+    if (warned) {
+        fprintf(stderr, "%s: corrupted data points in file\n", fname);
+        return;
+    }
     if (n == 0) {
         fprintf(stderr, "%s: no data points in file\n", fname);
         return;


### PR DESCRIPTION
Attempt to allow commented line or end-of-line in input data files.
Along the way the parsing errors machinery was fixed.