### PR TITLE
harden test nachinery: data access

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,4 +1,5 @@
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../src)
+add_definitions(-DDATADIR=\"${CMAKE_CURRENT_SOURCE_DIR}/../data\")
 
 set(TEST_CASES kolmogorov discrete continuous gss real sampling
 	underflow_handling)

--- a/test/test_common.c
+++ b/test/test_common.c
@@ -21,7 +21,14 @@
 
 size_t test_read_file(const char* fname, double* data, size_t max_n) {
 	size_t n = 0;
-	const char* prefixes[] = { "./", "../data/", "../../data/", 0 };
+	const char* prefixes[] = {
+		"./",
+		"../data/",
+		"../../data/",
+#ifdef DATADIR
+		DATADIR "/" ,
+#endif
+		0 };
 	const char** prefix_ptr;
 	char fname_with_path[4096];
 	FILE* f = 0;

--- a/test/test_python_module.py
+++ b/test/test_python_module.py
@@ -9,7 +9,16 @@ sys.path.insert(0, 'src')
 sys.path.insert(0, 'build/src')
 
 import plfit
-DATA_DIR = "data"
+
+prefixes = [ "data", "../data", "../../data" ]
+if 'DATADIR' in os.environ:
+	prefixes.append(os.environ.get('DATADIR'))
+
+DATA_DIR=None
+for prefix in prefixes:
+	if os.path.isdir(prefix):
+		DATA_DIR=prefix
+		break
 
 if not os.path.isdir(DATA_DIR):
     print("Can't find the data directory!", file=sys.stderr)

--- a/test/test_python_module.py
+++ b/test/test_python_module.py
@@ -12,13 +12,13 @@ import plfit
 
 prefixes = [ "data", "../data", "../../data" ]
 if 'DATADIR' in os.environ:
-	prefixes.append(os.environ.get('DATADIR'))
+    prefixes.append(os.environ.get('DATADIR'))
 
 DATA_DIR=None
 for prefix in prefixes:
-	if os.path.isdir(prefix):
-		DATA_DIR=prefix
-		break
+    if os.path.isdir(prefix):
+        DATA_DIR=prefix
+        break
 
 if not os.path.isdir(DATA_DIR):
     print("Can't find the data directory!", file=sys.stderr)


### PR DESCRIPTION
Description: harden test nachinery: data access
 Harmonize data access between C tests and Python tests;
 Introduce DATADIR macro in order to pass exotic location
 at running time. Meant to be submitted to the upstream
 maintainer.
Origin: debian
Comment: hardening tests
Author: Jerome Benoit <calculus@rezozer.net>
Last-Update: 2021-07-16