### PR TITLE
enhance tests: discard unneeded config header

### DIFF
--- a/test/test_common.h
+++ b/test/test_common.h
@@ -20,8 +20,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-#include "platform.h"
-
 #define RUN_TEST_CASE(func, label) do { \
     int result; \
     fprintf(stderr, "Testing " label "...\n"); \


### PR DESCRIPTION
Description: enhance tests: discard unneeded config header
 Discard inclusion of the platform header in tests as it
 appears not necessary while it is confusing.
 Meant to be submitted to the upstream maintainer.
Origin: debian
Comment: better integration: tests
Author: Jerome Benoit <calculus@rezozer.net>
Last-Update: 2021-07-16