### PR TITLE
cmake material: C only project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ project(
   VERSION 0.9.0
   DESCRIPTION "Library to fitt power-law distributions to empirical data"
   HOMEPAGE_URL "https://github.com/ntamas/plfit"
-  LANGUAGES C CXX
+  LANGUAGES C
 )
 enable_testing()
 


### PR DESCRIPTION
Description: cmake material: C only project
 Since the code contains no C++ specific code, it is
 more accurate to set C as LANGUAGES. End developers
 may know that they can easily integrate C material
 in their C++ projects if necessary.
Origin: debian
Comment: better integration
Author: Jerome Benoit <calculus@rezozer.net>
Last-Update: 2021-11-11