### PR TITLE
src/CMakeLists.txt: link libplfit against $MATH_LIBRARY

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -13,6 +13,7 @@ set(PLFIT_CORE_SRCS error.c gss.c kolmogorov.c lbfgs.c mt.c platform.c plfit.c o
 add_library(plfit ${PLFIT_CORE_SRCS})
 target_include_directories(plfit PUBLIC ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
 set_target_properties(plfit PROPERTIES SOVERSION 0)
+target_link_libraries(plfit ${MATH_LIBRARY})
 
 if(PLFIT_USE_OPENMP AND OPENMP_FOUND)
     target_link_libraries(plfit OpenMP::OpenMP_C)


### PR DESCRIPTION
The libplfit library makes use of several math functions (exp, log, ...) , and so should be linked to libm directly when libm is required for those functions. If it is not, then compilation may succeed leaving the resulting library underlinked. This can lead to errors like,

```
test_discrete: symbol lookup error: .../src/libplfit.so.0: undefined symbol: log
```

when linking with lld and `LDFLAGS="Wl,--as-needed"`. (The error above comes from plfit's own test suite.)


Gentoo-bug: https://bugs.gentoo.org/926433