### PR TITLE
refactor: better workaround for Windows 11 SDK bug where NAN is defined ni a non-constant way

### DIFF
--- a/src/hzeta.c
+++ b/src/hzeta.c
@@ -46,22 +46,22 @@
 #define _USE_MATH_DEFINES
 #endif
 
-#include <math.h>
-#include <stdio.h>
-#include "hzeta.h"
-#include "plfit_error.h"
-
 /* Work around bug in some Windows SDK / MSVC versions where NAN is not a
  * constant expression, triggering an error in the definition of
  * hsl_sf_hzeta_eulermaclaurin_series_coeffs[] and
  * hsl_sf_hzeta_eulermaclaurin_series_majorantratios[] below.
  * We re-define NAN to the value it had in earlier MSVC versions.
  * See https://github.com/igraph/igraph/issues/2701
+ * and https://developercommunity.visualstudio.com/t/NAN-is-no-longer-compile-time-constant-i/10688907
  */
 #ifdef _MSC_VER
-#undef NAN
-#define NAN (-(float)(((float)(1e+300 * 1e+300)) * 0.0F))
+#define _UCRT_NOISY_NAN
 #endif
+
+#include <math.h>
+#include <stdio.h>
+#include "hzeta.h"
+#include "plfit_error.h"
 
 /* imported from gsl_machine.h */
 


### PR DESCRIPTION
The title describes the fix. It's already in igraph. This is in response to https://stackoverflow.com/a/79324199/695132

The same approach is used by MPV here: https://github.com/mpv-player/mpv/pull/15325